### PR TITLE
Fix an 'unbound session' error.

### DIFF
--- a/github2fedmsg/views/__init__.py
+++ b/github2fedmsg/views/__init__.py
@@ -31,8 +31,9 @@ def home(request):
 @view_config(name='sync', context=m.User, renderer='json')
 def sync_user(request):
     # TODO -- someday, learn how to do the __acls__ thing.. :/
+    username = request.context.username
     userid = authenticated_userid(request)
-    if userid != request.context.username:
+    if userid != username:
         raise HTTPUnauthorized()
 
     config_key = 'github.secret_oauth_access_token'
@@ -43,7 +44,7 @@ def sync_user(request):
     request.context.sync_repos(oauth_creds)
     transaction.commit()
     home = request.route_url('home')
-    raise HTTPFound(home + request.context.username)
+    raise HTTPFound(home + username)
 
 
 @view_config(context="tw2.core.widgets.WidgetMeta",


### PR DESCRIPTION
The problem is that `request.context` (which is a sqlalchemy user
object bound to a session), cannot have its attributes referenced after
`transaction.commit()` has been called.  This just saves the username
before that happens so we can use it at the end.

This was causing tracebacks for anyone who tried to refresh/sync their
account with github.  The sync would succeed with
`transaction.commit()`, but after that the user would get a 500 error
(and be confused).
