### PR TITLE
Mark resources as traversed.

### DIFF
--- a/github2fedmsg/models/__init__.py
+++ b/github2fedmsg/models/__init__.py
@@ -151,7 +151,9 @@ class User(Base):
         return str(self.created_on)
 
     def __getitem__(self, key):
-        if key == self.github_username:
+        already_visited = getattr(self, '_visited', False)
+        if not already_visited and key == self.github_username:
+            self._visisted = True
             return self
 
         for r in self.repos:


### PR DESCRIPTION
This avoids the situation @puiterwijk ran into where if you have the
same username and reponame, then github2fedmsg's traversal mechanism
will revisit the same node in the tree and wind up with a 404.
