### PR TITLE
Typofix

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -11,7 +11,7 @@ sqlalchemy.url = sqlite:///%(here)s/github2fedmsg.db
 mako.directories = github2fedmsg:templates
 
 # github2fedmsg developer key.
-velruse.github.consumer_key = 85eb0789a638bd371318
+velruse.github.consumer_key = ee676d3349157a49fbbd
 velruse.github.scope = read:org,admin:repo_hook
 
 # For talking with FAS

--- a/github2fedmsg/models/__init__.py
+++ b/github2fedmsg/models/__init__.py
@@ -153,7 +153,7 @@ class User(Base):
     def __getitem__(self, key):
         already_visited = getattr(self, '_visited', False)
         if not already_visited and key == self.github_username:
-            self._visisted = True
+            self._visited = True
             return self
 
         for r in self.repos:


### PR DESCRIPTION
This made is so that you couldn't turn on repositories that had the same
name as their owner.  @abompard reported this when he couldn't get his
``hyperkitty/hyperkitty`` repository to work.  I reproduced it with a
``ralphbean/ralphbean`` repository.  This typofix gets it working again.

Traversal.  :left_luggage: