### PR TITLE
Change the method name to `get_repos` from `get_all`

### DIFF
--- a/github2fedmsg/githubutils.py
+++ b/github2fedmsg/githubutils.py
@@ -96,5 +96,5 @@ if __name__ == '__main__':
     username = raw_input("GitHub Username: ")
     password = getpass.getpass()
 
-    results = get_all(username, (username, password))
+    results = get_repos(username, (username, password))
     print len(results), "repos found."


### PR DESCRIPTION
The `get_all` method does not exist so changing the name to `get_repos` as the
scripts prints the number of repos.
