### PR TITLE
Careful with keys.

### DIFF
--- a/github2fedmsg/views/webhooks.py
+++ b/github2fedmsg/views/webhooks.py
@@ -169,8 +169,16 @@ def build_fas_lookup(payload):
     # Trawl through every possible corner we can to find github usernames
     if 'commits' in payload:
         for commit in payload['commits']:
-            usernames.add(commit['committer']['username'])
-            usernames.add(commit['author']['username'])
+            if 'committer' in commit:
+                if 'username' in commit['committer']:
+                    usernames.add(commit['committer']['username'])
+                elif 'name' in commit['committer']:
+                    usernames.add(commit['committer']['name'])
+            if 'author' in commit:
+                if 'username' in commit['author']:
+                    usernames.add(commit['author']['username'])
+                elif 'name' in commit['author']:
+                    usernames.add(commit['author']['name'])
 
     if 'pusher' in payload:
         usernames.add(payload['pusher']['name'])


### PR DESCRIPTION
@jdcasey reported this.

It seems that github.com is sending a new or modified message type that has a
`committer` field in the commit, but with no `username` field.  It instead has
a `user`.  We were raising `KeyError` exceptions when these got sent.

This should treat those messages more carefully.