### PR TITLE
README: link to github category on datagrepper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ It is a web application that monitors GitHub repositories you subscribe it to.
 When new actions (commits, pull-request, tickets) are made, it broadcasts a
 message on the `fedmsg`_ message bus.
 
+You can see all the current messages with `datagrepper's "github" category
+<https://apps.fedoraproject.org/datagrepper/raw?category=github>`_.
+
 It is written in Python on the Pyramid framework, and uses `velruse
 <http://velruse.rtfd.org>`_ to talk with GitHub.  It adds a webhook callback
 back to itself on repositories you ask it to monitor.  When one of those


### PR DESCRIPTION
Make it easier for users to discover examples of all the messages that github2fedmsg emits.