### PR TITLE
README: shorten datagrepper delta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ When new actions (commits, pull-request, tickets) are made, it broadcasts a
 message on the `fedora-messaging`_ message bus.
 
 You can see all the current messages with `datagrepper's "github" category
-<https://apps.fedoraproject.org/datagrepper/raw?category=github>`_.
+<https://apps.fedoraproject.org/datagrepper/raw?category=github&delta=3600>`_.
 
 It is written in Python on the Pyramid framework, and uses `velruse
 <http://velruse.rtfd.org>`_ to talk with GitHub.  It adds a webhook callback


### PR DESCRIPTION
Datagrepper's web UI defaults to a large `delta` setting, and this makes the web UI URL timeout after many seconds.

Add a short `delta` argument to our datagrepper URL so that the page loads right away. The github category is normally very active so users will still see a good sample representation of the GitHub messages, and users can also scroll down to see earlier messages.